### PR TITLE
JE-001: consolidate canonical metadata ownership

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,7 +6,6 @@
 <meta name="keywords" content="{{ site.keywords }}">
 <meta name="twitter:description" content="{%- if page.summary -%}{{ page.summary | strip_html | strip_newlines | truncate: 160 }}{%- else -%}{{ site.description }}{%- endif -%}">
 
-<link rel="canonical" href="{{ page.url | replace:'index.html','' |  prepend: site.url }}">
 <link rel="alternate" type="application/atom+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.url }}">
 
 {%- include head/icons.html -%}


### PR DESCRIPTION
EGCA experiment JE-001.

Bounded theme change: remove only the hand-written canonical tag and delegate canonical ownership to jekyll-seo-tag. The current JLSunday baseline demonstrates that the plugin already emits canonical metadata, while the currently observed plugin output does not emit twitter:description, so the custom twitter description remains for now.

This PR is intentionally draft and must not merge until the consuming-site build/output evidence is reviewed and the EGCA decision is recorded.