### PR TITLE
Fix Algolia indexing workflow

### DIFF
--- a/.github/workflows/algolia-search.yml
+++ b/.github/workflows/algolia-search.yml
@@ -1,13 +1,19 @@
+name: algolia-search
+
 on:
   push:
     branches:
       - master
       - main
+  workflow_dispatch:
 
-name: algolia-search
+permissions:
+  contents: read
+
 jobs:
   algolia-search:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -16,14 +22,17 @@ jobs:
           ruby-version: '3.2'
           bundler-cache: true
 
-      - uses: actions/cache@v2.1.6
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
+      - name: Verify Algolia API key
+        env:
+          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+        run: |
+          if [ -z "$ALGOLIA_API_KEY" ]; then
+            echo "ALGOLIA_API_KEY secret is not configured."
+            exit 1
+          fi
 
-      - name: Algolia Jekyll Action
-        uses: dieghernan/algolia-jekyll-action@v1
-        with:
-          APIKEY: '${{ secrets.ALGOLIA_API_KEY }}'
+      - name: Update Algolia search index
+        env:
+          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+          JEKYLL_ENV: production
+        run: bundle exec jekyll algolia


### PR DESCRIPTION
Applies the proven Algolia workflow fix already used in JLSunday PR #19.

Changes:
- Remove the `dieghernan/algolia-jekyll-action@v1` wrapper so the job stays in the repository's Ruby 3.2 / Bundler environment.
- Run `bundle exec jekyll algolia` directly; `jekyll-algolia` is already declared in the Gemfile.
- Add an explicit `ALGOLIA_API_KEY` preflight failure.
- Add `workflow_dispatch` for manual index refreshes.
- Add a 15-minute job timeout.
- Set least-privilege `contents: read` permissions.
- Remove the redundant legacy `actions/cache` step because `ruby/setup-ruby` already provides Bundler caching.

This is maintenance for known pre-existing deployment debt, not part of EGCA JE-002. Please do not merge until reviewed; the merge itself will provide the definitive push-triggered Algolia test on `main`.