### PR TITLE
Use canonical project data on homepage

### DIFF
--- a/_includes/home.html
+++ b/_includes/home.html
@@ -74,7 +74,8 @@
     </section>
     {% endif %}
 
-    {% if homepage.projects %}
+    {%- assign homepage_projects = site.data.projects | where: "homepage", true | sort: "homepage_order" -%}
+    {% unless homepage_projects == empty %}
     <section class="py-5 border-top" aria-labelledby="selected-projects-heading">
         <div class="d-flex justify-content-between align-items-end gap-3 mb-4">
             <div>
@@ -84,20 +85,20 @@
             {% if homepage.projects_url %}<a href="{{ homepage.projects_url }}">View all projects</a>{% endif %}
         </div>
         <div class="row g-4">
-            {% for project in homepage.projects %}
-            <div class="col-md-6 d-flex">
+            {% for project in homepage_projects %}
+            <div class="col-md-6 col-lg-4 d-flex">
                 <div class="card h-100 w-100">
                     <div class="card-body">
-                        <h3 class="h4 card-title"><a class="stretched-link" href="{{ project.url }}">{{ project.title }}</a></h3>
+                        <h3 class="h4 card-title"><a class="stretched-link" href="{{ project.website | default: homepage.projects_url }}">{{ project.name }}</a></h3>
                         <p class="card-text">{{ project.description }}</p>
-                        {% if project.technologies %}<p class="small text-body-secondary mb-0">{{ project.technologies | join: " · " }}</p>{% endif %}
+                        {% if project.skills %}<p class="small text-body-secondary mb-0">{{ project.skills | join: " · " }}</p>{% endif %}
                     </div>
                 </div>
             </div>
             {% endfor %}
         </div>
     </section>
-    {% endif %}
+    {% endunless %}
 
     <section class="py-5 border-top" aria-labelledby="latest-writing-heading">
         <p class="text-uppercase text-body-secondary fw-semibold mb-1">From the blog</p>


### PR DESCRIPTION
Refactors the homepage Selected Projects section to read from the canonical `site.data.projects` dataset instead of requiring duplicated project metadata in `site.data.homepage`.

Projects opt into homepage presentation with lightweight `homepage: true` and optional `homepage_order` fields. The homepage renders canonical `name`, `description`, `website`, and `skills` values, while the existing `/projects` page continues to use the same dataset unchanged.

This is an architecture cleanup discovered during implementation, not a new EGCA experiment. Do not merge until the consuming JLSunday PR validates the cross-repo behavior.