### PR TITLE
Cache-bust generated theme stylesheet

### DIFF
--- a/_includes/head/stylesheets.html
+++ b/_includes/head/stylesheets.html
@@ -1,2 +1,2 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/night-owl.min.css" integrity="sha512-i5X6Fdn/ZqvGSqPrdMa3FgcpXM/Nr6YccSKFYT93zljl/HZDEpvBbE5Pxp91eiWGccZLrL/LDQJd7fjTRYsVaA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-<link rel="stylesheet" href="{{ "/assets/scss/main.css" | prepend: site.url }}">
+<link rel="stylesheet" href="{{ "/assets/scss/main.css" | relative_url }}?v={{ site.time | date: "%s" }}">


### PR DESCRIPTION
Fixes the post-merge TOC/mobile-reading regression caused by browsers/CDN reusing the old `main.css` URL after the new markup and JavaScript deployed. The generated stylesheet URL now carries a build-specific query parameter so HTML and CSS stay in sync across theme deployments.