### PR TITLE
JE-004: modernize code blocks

### DIFF
--- a/_includes/footer/code-block-lang.html
+++ b/_includes/footer/code-block-lang.html
@@ -1,12 +1,88 @@
 <script>
-document.querySelectorAll(".highlighter-rouge, figure.highlight").forEach(i => {
-    i.setAttribute("data-lang", "code");
-    var l = i.getAttribute("class").split("language-");
-    if (l.length > 1) {
-        var lang = l[1].split(" ");
-        if (lang.length > 0) {
-        i.setAttribute("data-lang", lang[0]);
+(function () {
+    function getLanguage(container) {
+        const className = container.className || '';
+        const match = className.match(/(?:^|\s)language-([^\s]+)/);
+        if (match) return match[1];
+
+        const code = container.querySelector('code[class*="language-"]');
+        if (code) {
+            const codeMatch = code.className.match(/(?:^|\s)language-([^\s]+)/);
+            if (codeMatch) return codeMatch[1];
         }
+
+        return 'code';
     }
-});
+
+    function getCodeText(container) {
+        const codeCell = container.querySelector('.rouge-table td.code pre, .rouge-table td.code code');
+        if (codeCell) return codeCell.innerText;
+
+        const code = container.querySelector('pre code, code');
+        if (code) return code.innerText;
+
+        const pre = container.querySelector('pre');
+        return pre ? pre.innerText : '';
+    }
+
+    function initializeCodeBlocks() {
+        const blocks = document.querySelectorAll('.highlighter-rouge, figure.highlight');
+
+        blocks.forEach((block, index) => {
+            if (block.dataset.codeEnhanced === 'true') return;
+            block.dataset.codeEnhanced = 'true';
+            block.dataset.lang = getLanguage(block);
+
+            const toolbar = document.createElement('div');
+            toolbar.className = 'code-block-toolbar';
+
+            const language = document.createElement('span');
+            language.className = 'code-block-language';
+            language.textContent = block.dataset.lang;
+            toolbar.appendChild(language);
+
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'code-copy-button';
+            button.setAttribute('aria-label', `Copy ${block.dataset.lang} code to clipboard`);
+            button.innerHTML = '<i class="bi bi-clipboard" aria-hidden="true"></i><span>Copy</span>';
+
+            button.addEventListener('click', async () => {
+                const text = getCodeText(block);
+                if (!text) return;
+
+                try {
+                    await navigator.clipboard.writeText(text);
+                    button.classList.add('copied');
+                    button.querySelector('span').textContent = 'Copied';
+                    button.querySelector('i').className = 'bi bi-check2';
+                    window.setTimeout(() => {
+                        button.classList.remove('copied');
+                        button.querySelector('span').textContent = 'Copy';
+                        button.querySelector('i').className = 'bi bi-clipboard';
+                    }, 1800);
+                } catch (error) {
+                    const selection = window.getSelection();
+                    const range = document.createRange();
+                    const target = block.querySelector('pre code, td.code pre, pre');
+                    if (!target) return;
+                    range.selectNodeContents(target);
+                    selection.removeAllRanges();
+                    selection.addRange(range);
+                    button.querySelector('span').textContent = 'Select & copy';
+                }
+            });
+
+            toolbar.appendChild(button);
+            block.insertBefore(toolbar, block.firstChild);
+            block.setAttribute('data-code-block', String(index + 1));
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initializeCodeBlocks);
+    } else {
+        initializeCodeBlocks();
+    }
+})();
 </script>

--- a/_includes/head/stylesheets.html
+++ b/_includes/head/stylesheets.html
@@ -1,2 +1,1 @@
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/night-owl.min.css" integrity="sha512-i5X6Fdn/ZqvGSqPrdMa3FgcpXM/Nr6YccSKFYT93zljl/HZDEpvBbE5Pxp91eiWGccZLrL/LDQJd7fjTRYsVaA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 <link rel="stylesheet" href="{{ "/assets/scss/main.css" | relative_url }}?v={{ site.time | date: "%s" }}">

--- a/_sass/_code-blocks.scss
+++ b/_sass/_code-blocks.scss
@@ -1,0 +1,121 @@
+.highlighter-rouge,
+figure.highlight {
+  position: relative;
+  margin: 1.5rem 0;
+  border: 1px solid var(--bs-border-color);
+  border-radius: .5rem;
+  overflow: hidden;
+  background: #2e3e4e;
+}
+
+.highlighter-rouge .code-block-toolbar,
+figure.highlight .code-block-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: 2.5rem;
+  padding: .45rem .65rem;
+  border-bottom: 1px solid rgba(255, 255, 255, .14);
+  background: rgba(0, 0, 0, .18);
+  color: #e9ecef;
+  font-family: $monospace-font-family;
+  font-size: .78rem;
+}
+
+.code-block-language {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-transform: lowercase;
+  opacity: .82;
+}
+
+.code-copy-button {
+  display: inline-flex;
+  align-items: center;
+  gap: .35rem;
+  flex: 0 0 auto;
+  padding: .25rem .5rem;
+  border: 1px solid rgba(255, 255, 255, .26);
+  border-radius: .35rem;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  line-height: 1.2;
+  cursor: pointer;
+}
+
+.code-copy-button:hover,
+.code-copy-button:focus-visible {
+  background: rgba(255, 255, 255, .1);
+  border-color: rgba(255, 255, 255, .45);
+}
+
+.code-copy-button:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+.code-copy-button.copied {
+  border-color: #81ffd9;
+  color: #81ffd9;
+}
+
+.highlighter-rouge > .highlight,
+figure.highlight > pre,
+figure.highlight > table,
+.highlighter-rouge > pre,
+.highlighter-rouge > table {
+  margin: 0;
+  border-radius: 0;
+}
+
+.highlighter-rouge .highlight,
+figure.highlight,
+.highlighter-rouge pre,
+figure.highlight pre {
+  max-height: none;
+}
+
+.highlighter-rouge pre,
+figure.highlight pre {
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding: 1rem;
+  margin-bottom: 0;
+  scrollbar-gutter: stable;
+}
+
+.rouge-table {
+  width: max-content;
+  min-width: 100%;
+  margin: 0;
+}
+
+.rouge-table td.gutter {
+  user-select: none;
+  color: #adb5bd;
+}
+
+.rouge-table td.code pre {
+  overflow: visible;
+}
+
+@media (max-width: 575.98px) {
+  .code-copy-button span {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .code-copy-button {
+    padding: .35rem .45rem;
+  }
+}

--- a/_sass/_code-blocks.scss
+++ b/_sass/_code-blocks.scss
@@ -1,3 +1,8 @@
+figure.highlight::before,
+div.highlighter-rouge::before {
+  display: none;
+}
+
 .highlighter-rouge,
 figure.highlight {
   position: relative;

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -113,6 +113,7 @@ $on-laptop:        800px;
 @import
         "base",
         "_syntax-highlighting",
+        "_code-blocks",
         "_navigation"
 ;
 


### PR DESCRIPTION
Implements JE-004 by simplifying code rendering to Jekyll/Kramdown + Rouge and using client-side JavaScript only for progressive code-block enhancements. Removes the unused Highlight.js theme stylesheet, adds accessible language labels and copy-to-clipboard controls, preserves Rouge line-number output, and improves responsive overflow/styling. A companion JLSunday PR validates the exact theme commit against real posts.