### PR TITLE
Fix inline code regression from JE-004

### DIFF
--- a/_includes/footer/code-block-lang.html
+++ b/_includes/footer/code-block-lang.html
@@ -18,7 +18,7 @@
         const codeCell = container.querySelector('.rouge-table td.code pre, .rouge-table td.code code');
         if (codeCell) return codeCell.innerText;
 
-        const code = container.querySelector('pre code, code');
+        const code = container.querySelector('pre code');
         if (code) return code.innerText;
 
         const pre = container.querySelector('pre');
@@ -26,7 +26,8 @@
     }
 
     function initializeCodeBlocks() {
-        const blocks = document.querySelectorAll('.highlighter-rouge, figure.highlight');
+        const candidates = document.querySelectorAll('div.highlighter-rouge, figure.highlight');
+        const blocks = Array.from(candidates).filter(block => block.querySelector('pre'));
 
         blocks.forEach((block, index) => {
             if (block.dataset.codeEnhanced === 'true') return;

--- a/_sass/_code-blocks.scss
+++ b/_sass/_code-blocks.scss
@@ -3,7 +3,7 @@ div.highlighter-rouge::before {
   display: none;
 }
 
-.highlighter-rouge,
+div.highlighter-rouge,
 figure.highlight {
   position: relative;
   margin: 1.5rem 0;
@@ -13,7 +13,7 @@ figure.highlight {
   background: #2e3e4e;
 }
 
-.highlighter-rouge .code-block-toolbar,
+div.highlighter-rouge .code-block-toolbar,
 figure.highlight .code-block-toolbar {
   display: flex;
   align-items: center;
@@ -67,23 +67,23 @@ figure.highlight .code-block-toolbar {
   color: #81ffd9;
 }
 
-.highlighter-rouge > .highlight,
+div.highlighter-rouge > .highlight,
 figure.highlight > pre,
 figure.highlight > table,
-.highlighter-rouge > pre,
-.highlighter-rouge > table {
+div.highlighter-rouge > pre,
+div.highlighter-rouge > table {
   margin: 0;
   border-radius: 0;
 }
 
-.highlighter-rouge .highlight,
+div.highlighter-rouge .highlight,
 figure.highlight,
-.highlighter-rouge pre,
+div.highlighter-rouge pre,
 figure.highlight pre {
   max-height: none;
 }
 
-.highlighter-rouge pre,
+div.highlighter-rouge pre,
 figure.highlight pre {
   overflow-x: auto;
   overflow-y: hidden;


### PR DESCRIPTION
Scopes JE-004 code-block enhancement and styling to true block-level Rouge containers only. Inline `<code class="highlighter-rouge">` spans are no longer wrapped with language/copy toolbars or block chrome. This fixes the production regression visible in the newest JLSunday article while preserving fenced-code enhancements.