### PR TITLE
Fix logo source after navigation refactor

### DIFF
--- a/_includes/footer/color_theme_toggler.html
+++ b/_includes/footer/color_theme_toggler.html
@@ -58,10 +58,19 @@
     }
   };
 
+  const lightLogo = '{{ site.logo_light | prepend: site.url }}';
+  const darkLogo = '{{ site.logo_dark | prepend: site.url }}';
+
   const setLogo = themeColor => {
-    const themeLogo = themeColor == 'dark' ? '{{ siteLogoDark }}' : '{{ siteLogoLight }}';
-    const logoImgElement = document.getElementById("site-logo");
-    logoImgElement.setAttribute('src', themeLogo);
+    const logoImgElement = document.getElementById('site-logo');
+    if (!logoImgElement) {
+      return;
+    }
+
+    const themeLogo = themeColor == 'dark' ? darkLogo : lightLogo;
+    if (themeLogo) {
+      logoImgElement.setAttribute('src', themeLogo);
+    }
   };
 
   window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {


### PR DESCRIPTION
Fixes the logo regression introduced by CI-009. The color-theme toggler no longer depends on `siteLogoLight` / `siteLogoDark` variables assigned by another include; it resolves `site.logo_light` and `site.logo_dark` directly and safely no-ops if the logo element is absent. This removes fragile cross-include state and preserves light/dark logo switching.