### PR TITLE
Fix logo asset URL generation

### DIFF
--- a/_includes/footer/color_theme_toggler.html
+++ b/_includes/footer/color_theme_toggler.html
@@ -58,8 +58,8 @@
     }
   };
 
-  const lightLogo = '{{ site.logo_light | prepend: site.url }}';
-  const darkLogo = '{{ site.logo_dark | prepend: site.url }}';
+  const lightLogo = '{{ site.logo_light | relative_url }}';
+  const darkLogo = '{{ site.logo_dark | relative_url }}';
 
   const setLogo = themeColor => {
     const logoImgElement = document.getElementById('site-logo');

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -5,7 +5,7 @@
     <a class="navbar-brand" href="{{ '/' | relative_url }}" aria-label="{{ site.title }} home">
       <img
         id="site-logo"
-        src="{{ site.logo_light | prepend: site.url }}"
+        src="{{ site.logo_light | relative_url }}"
         alt="{{ site.title }}"
         width="200"
       />


### PR DESCRIPTION
Replaces absolute logo URL construction (`prepend: site.url`) with Jekyll's `relative_url` filter in both the navigation image and theme-switcher script. The configured logo asset exists in JLSunday; this keeps site-owned assets on the current origin and avoids build-context-dependent absolute URL construction.