### PR TITLE
CI-015: add reusable project case-study support

### DIFF
--- a/_includes/projects/project-card.html
+++ b/_includes/projects/project-card.html
@@ -1,75 +1,77 @@
-<div id="project-{{ proj.name }}" class="card h-100 d-block">
-    <div class="card-body">
-        <h2 class="card-title">{{ proj.name }}</h2>
-        <div class="card-text">
-            {%- if proj.start-year and proj.start-year != "" -%}
-                <p><b>Project Started</b>: {{ proj.start-year }}</p>
-            {%- endif -%}
-            {%- if proj.end-year and proj.end-year != "" and proj.ongoing == false -%}
-                <p><b>Project Ended</b>: {{ proj.end-year }}</p>
-            {%- endif -%}
-            {%- if proj.ongoing and proj.ongoing == true -%}
-                <p><b>Project Ended</b>: Ongoing</p>
-            {%- endif -%}
-            {%- if proj.website != "" -%}
-                <p>
-                    <b>Project Website</b>:
-                    <a
-                            href="{{ proj.website }}"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            title="{{ proj.website }}"
-                    >
-                        {{ proj.website }}
-                    </a>
-                </p>
-            {%- endif -%}
-            {%- if proj.client and proj.client.name != '' -%}
-                <p>
-                    <b>Client</b>:
-                    {%- if proj.client.website != '' -%}
-                        <a
-                                href="{{ proj.client.website }}"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                title="{{ proj.client.website }}"
-                        >
-                            {{ proj.client.name }}
-                        </a>
-                    {%- else -%}
-                        {{ proj.client.name }}
-                    {%- endif -%}
-                </p>
-            {%- endif -%}
-            {% if proj.tags %}
-                <p>
-                    <b>Tags</b>: {{ proj.tags | array_to_sentence_string }}
-                </p>
-            {% endif %}
-            {% if proj.skills %}
-                <p><b>Skills</b>: {{ proj.skills | array_to_sentence_string }}</p>
-            {% endif %}
-            {% if proj.description %}
-                <p>
-                    <b>Description</b>: <br>
-                </p>
-                    <p>{{ proj.description }}</p>
-            {% endif %}
-            <p><b>Project Images</b>:<br></p>
-            <div class="container row">
-                {%- for image in proj.images -%}
-                    <div class="col-sm-12 col-md-6">
-                        <figure>
-                            <a href="{{ image.path | prepend: site.url }}" target="_blank" rel="noopener noreferrer">
-                                <img alt="{{ image.title }}" src="{{ image.path | prepend: site.url }}" loading="lazy" title="Click to see larger image">
-                            </a>
-                            <figcaption>
-                                {{ image.caption }}
-                            </figcaption>
-                        </figure>
-                    </div>
-                {%- endfor -%}
-            </div>
-        </div>
+<article id="project-{{ proj.slug | default: proj.name | slugify }}" class="card project-card h-100 d-block">
+  <div class="card-body">
+    <div class="d-flex flex-column flex-lg-row justify-content-between gap-3 align-items-lg-start">
+      <div>
+        <h2 class="card-title h3 mb-2">{{ proj.name }}</h2>
+        {% if proj.summary %}
+          <p class="project-card-summary lead mb-3">{{ proj.summary }}</p>
+        {% elsif proj.description %}
+          <p class="project-card-summary mb-3">{{ proj.description | truncatewords: 45 }}</p>
+        {% endif %}
+      </div>
+      {% if proj.status or proj.ongoing == true %}
+        <span class="badge text-bg-secondary align-self-start">
+          {{ proj.status | default: "Ongoing" }}
+        </span>
+      {% endif %}
     </div>
-</div>
+
+    {% if proj.skills %}
+      <ul class="project-chip-list list-unstyled d-flex flex-wrap gap-2 mb-3" aria-label="Technologies used">
+        {% for skill in proj.skills %}
+          <li><span class="badge rounded-pill text-bg-light border">{{ skill }}</span></li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+
+    {% if proj.highlights %}
+      <ul class="project-highlights mb-3">
+        {% for highlight in proj.highlights limit: 4 %}
+          <li>{{ highlight }}</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+
+    <dl class="project-meta row mb-3">
+      {% if proj.role %}
+        <dt class="col-sm-3">Role</dt><dd class="col-sm-9">{{ proj.role }}</dd>
+      {% endif %}
+      {% if proj.start-year %}
+        <dt class="col-sm-3">Timeline</dt>
+        <dd class="col-sm-9">
+          {{ proj.start-year }}{% if proj.ongoing == true %}–present{% elsif proj.end-year %}–{{ proj.end-year }}{% endif %}
+        </dd>
+      {% endif %}
+      {% if proj.tags %}
+        <dt class="col-sm-3">Focus</dt><dd class="col-sm-9">{{ proj.tags | array_to_sentence_string }}</dd>
+      {% endif %}
+    </dl>
+
+    <div class="project-actions d-flex flex-wrap gap-2 mb-3">
+      {% if proj.case_study %}
+        <a class="btn btn-primary" href="{{ proj.case_study | relative_url }}">Read case study</a>
+      {% endif %}
+      {% if proj.website %}
+        <a class="btn btn-outline-secondary" href="{{ proj.website }}" target="_blank" rel="noopener noreferrer">Visit project</a>
+      {% endif %}
+      {% if proj.repository %}
+        <a class="btn btn-outline-secondary" href="{{ proj.repository }}" target="_blank" rel="noopener noreferrer">View source</a>
+      {% endif %}
+    </div>
+
+    {% if proj.images %}
+      <div class="project-image-grid row g-3">
+        {% for image in proj.images limit: 4 %}
+          <div class="col-sm-12 col-md-6">
+            <figure class="mb-0">
+              <a href="{{ image.path | relative_url }}" target="_blank" rel="noopener noreferrer">
+                <img class="img-fluid rounded" alt="{{ image.title }}" src="{{ image.path | relative_url }}" loading="lazy" title="Click to see larger image">
+              </a>
+              {% if image.caption %}<figcaption class="small mt-1">{{ image.caption }}</figcaption>{% endif %}
+            </figure>
+          </div>
+        {% endfor %}
+      </div>
+    {% endif %}
+  </div>
+</article>

--- a/_layouts/project-case-study.html
+++ b/_layouts/project-case-study.html
@@ -1,0 +1,79 @@
+---
+layout: default
+---
+{%- assign project = site.data.projects | where: "slug", page.project | first -%}
+
+<article class="project-case-study">
+  <header class="project-case-study-header mb-5">
+    <p class="text-uppercase small fw-semibold mb-2">Project case study</p>
+    <h1 class="display-5 mb-3">{{ project.name | default: page.title | escape }}</h1>
+
+    {% if project.summary %}
+      <p class="lead project-case-study-summary">{{ project.summary }}</p>
+    {% elsif page.description %}
+      <p class="lead project-case-study-summary">{{ page.description }}</p>
+    {% endif %}
+
+    {% if project %}
+      <div class="project-case-study-facts row g-3 mt-2">
+        {% if project.role %}
+          <div class="col-sm-6 col-lg-3"><strong class="d-block">Role</strong>{{ project.role }}</div>
+        {% endif %}
+        {% if project.start-year %}
+          <div class="col-sm-6 col-lg-3">
+            <strong class="d-block">Timeline</strong>
+            {{ project.start-year }}{% if project.ongoing == true %}–present{% elsif project.end-year %}–{{ project.end-year }}{% endif %}
+          </div>
+        {% endif %}
+        {% if project.status %}
+          <div class="col-sm-6 col-lg-3"><strong class="d-block">Status</strong>{{ project.status }}</div>
+        {% endif %}
+        {% if project.skills %}
+          <div class="col-sm-12 col-lg-6"><strong class="d-block">Stack</strong>{{ project.skills | array_to_sentence_string }}</div>
+        {% endif %}
+      </div>
+
+      <div class="project-actions d-flex flex-wrap gap-2 mt-4">
+        {% if project.website %}
+          <a class="btn btn-primary" href="{{ project.website }}" target="_blank" rel="noopener noreferrer">Visit project</a>
+        {% endif %}
+        {% if project.repository %}
+          <a class="btn btn-outline-secondary" href="{{ project.repository }}" target="_blank" rel="noopener noreferrer">View source</a>
+        {% endif %}
+      </div>
+    {% endif %}
+  </header>
+
+  {% if project.highlights %}
+    <aside class="project-case-study-highlights mb-5" aria-labelledby="project-highlights-heading">
+      <h2 id="project-highlights-heading" class="h4">Highlights</h2>
+      <ul>
+        {% for highlight in project.highlights %}
+          <li>{{ highlight }}</li>
+        {% endfor %}
+      </ul>
+    </aside>
+  {% endif %}
+
+  <div class="project-case-study-content post-content">
+    {{ content }}
+  </div>
+
+  {% if project.images %}
+    <section class="project-case-study-gallery mt-5" aria-labelledby="project-gallery-heading">
+      <h2 id="project-gallery-heading">Screenshots</h2>
+      <div class="row g-4">
+        {% for image in project.images %}
+          <div class="col-12 col-lg-6">
+            <figure>
+              <a href="{{ image.path | relative_url }}" target="_blank" rel="noopener noreferrer">
+                <img class="img-fluid rounded" src="{{ image.path | relative_url }}" alt="{{ image.title }}" loading="lazy">
+              </a>
+              {% if image.caption %}<figcaption class="small mt-2">{{ image.caption }}</figcaption>{% endif %}
+            </figure>
+          </div>
+        {% endfor %}
+      </div>
+    </section>
+  {% endif %}
+</article>

--- a/_sass/_projects.scss
+++ b/_sass/_projects.scss
@@ -1,0 +1,64 @@
+.project-card {
+  border: 1px solid var(--bs-border-color);
+  box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.06);
+}
+
+.project-card .card-body {
+  padding: clamp(1.25rem, 2vw, 2rem);
+}
+
+.project-card-summary,
+.project-case-study-summary {
+  max-width: 72ch;
+}
+
+.project-chip-list .badge {
+  font-weight: 500;
+}
+
+.project-meta dt,
+.project-meta dd {
+  margin-bottom: 0.5rem;
+}
+
+.project-highlights,
+.project-case-study-highlights ul {
+  padding-left: 1.25rem;
+}
+
+.project-highlights li + li,
+.project-case-study-highlights li + li {
+  margin-top: 0.4rem;
+}
+
+.project-image-grid img,
+.project-case-study-gallery img {
+  width: 100%;
+  height: auto;
+}
+
+.project-case-study {
+  max-width: 980px;
+  margin-inline: auto;
+}
+
+.project-case-study-header {
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--bs-border-color);
+}
+
+.project-case-study-facts > div {
+  padding: 0.75rem 1rem;
+  border-left: 3px solid var(--bs-border-color);
+}
+
+.project-case-study-highlights {
+  padding: 1.25rem 1.5rem;
+  border: 1px solid var(--bs-border-color);
+  border-radius: 0.5rem;
+  background: var(--bs-tertiary-bg);
+}
+
+.project-case-study-content > :first-child {
+  margin-top: 0;
+}

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -114,7 +114,8 @@ $on-laptop:        800px;
         "base",
         "_syntax-highlighting",
         "_code-blocks",
-        "_navigation"
+        "_navigation",
+        "_projects"
 ;
 
 @import url('https://fonts.googleapis.com/css?family=Open+Sans');


### PR DESCRIPTION
Adds a reusable project case-study layout, richer portfolio-oriented project cards, and dedicated project presentation styles. The schema remains backward-compatible: existing sparse project records still render, while optional fields such as `slug`, `summary`, `role`, `status`, `highlights`, `repository`, and `case_study` enable richer presentation. JLSunday validates this branch against its real canonical `_data/projects.yml`.