### PR TITLE
Constrain mobile case study screenshots

### DIFF
--- a/_layouts/project-case-study.html
+++ b/_layouts/project-case-study.html
@@ -64,7 +64,11 @@ layout: default
       <h2 id="project-gallery-heading">Screenshots</h2>
       <div class="row g-4">
         {% for image in project.images %}
-          <div class="col-12 col-lg-6">
+          {% if image.mobile == true %}
+            <div class="col-12 col-sm-8 col-md-6 col-lg-4 mx-auto">
+          {% else %}
+            <div class="col-12 col-lg-6">
+          {% endif %}
             <figure>
               <a href="{{ image.path | relative_url }}" target="_blank" rel="noopener noreferrer">
                 <img class="img-fluid rounded" src="{{ image.path | relative_url }}" alt="{{ image.title }}" loading="lazy">


### PR DESCRIPTION
Adds an explicit `mobile: true` image metadata path for project case-study galleries. Mobile/portrait screenshots use a narrower centered Bootstrap column while desktop screenshots retain the existing two-column layout. This prevents narrow source images from being upscaled to an oversized half-width desktop presentation.