### PR TITLE
CI-017: add reusable author authority presentation

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -1,19 +1,48 @@
-<p>
-  Lorem ipsum, dolor sit amet consectetur adipisicing elit. Possimus tempore,
-  sint exercitationem accusamus libero iure magni eius vitae dolorem beatae cum
-  ullam iste odio quidem temporibus quisquam earum amet pariatur?
-</p>
+{%- include author-card.html variant="about" -%}
 
-## Contact Me
-<form action="https://fabform.io/f/{{site.fab_form}}" method="post">
+{%- if site.author.about -%}
+<section class="about-author my-4" aria-labelledby="about-author-heading">
+  <h2 id="about-author-heading">About my work</h2>
+  {%- for paragraph in site.author.about -%}
+    <p>{{ paragraph }}</p>
+  {%- endfor -%}
+</section>
+{%- endif -%}
+
+{%- if site.author.writing -%}
+<section class="about-writing my-4" aria-labelledby="about-writing-heading">
+  <h2 id="about-writing-heading">What I write about</h2>
+  <ul>
+    {%- for item in site.author.writing -%}
+      <li>{{ item }}</li>
+    {%- endfor -%}
+  </ul>
+</section>
+{%- endif -%}
+
+<section class="about-links my-4" aria-labelledby="about-links-heading">
+  <h2 id="about-links-heading">Explore my work</h2>
+  <p>
+    <a href="{{ '/projects/' | relative_url }}">Projects and engineering case studies</a>
+    ·
+    <a href="{{ '/' | relative_url }}">Latest writing</a>
+  </p>
+</section>
+
+{%- if site.fab_form -%}
+<section id="contact-me" class="my-4" aria-labelledby="contact-heading">
+  <h2 id="contact-heading">Contact me</h2>
+  <form action="https://fabform.io/f/{{ site.fab_form }}" method="post">
     <label for="firstName" class="form-label">First Name</label>
-    <input name="firstName" type="text" required class="form-control">
-    <label for="lastName" class="form-label">Last Name</label>
-    <input name="lastName" type="text" class="form-control">
-    <label for="email" class="form-label">Email</label>
-    <input name="email" type="email" required class="form-control">
-    <label for="message" class="form-label">Message</label>
-    <textarea name="message" required class="form-control" rows="10"></textarea>
-    <p>Powered by <a href="https://fabform.io" target="_blank">fabform.io</a></p>
+    <input id="firstName" name="firstName" type="text" required class="form-control">
+    <label for="lastName" class="form-label mt-3">Last Name</label>
+    <input id="lastName" name="lastName" type="text" class="form-control">
+    <label for="email" class="form-label mt-3">Email</label>
+    <input id="email" name="email" type="email" required class="form-control">
+    <label for="message" class="form-label mt-3">Message</label>
+    <textarea id="message" name="message" required class="form-control" rows="8"></textarea>
+    <p class="small text-body-secondary mt-2">Powered by <a href="https://fabform.io" target="_blank" rel="noopener noreferrer">fabform.io</a></p>
     <button class="btn btn-primary" type="submit">Submit</button>
-</form>
+  </form>
+</section>
+{%- endif -%}

--- a/_includes/author-card.html
+++ b/_includes/author-card.html
@@ -1,0 +1,71 @@
+{%- assign author = site.author -%}
+{%- assign variant = include.variant | default: "post" -%}
+{%- assign profile_image = author.image -%}
+{%- if profile_image == nil or profile_image == "" -%}
+  {%- if site.aboutme and site.aboutme.photo and site.aboutme.photo.asset_path -%}
+    {%- assign profile_image = site.aboutme.photo.asset_path -%}
+  {%- endif -%}
+{%- endif -%}
+
+<aside class="author-card card my-4" aria-label="About the author">
+  <div class="card-body">
+    <div class="d-flex flex-column flex-sm-row gap-3 align-items-sm-center">
+      {%- if profile_image and profile_image != "" -%}
+        <a href="{{ '/about/' | relative_url }}" class="flex-shrink-0" aria-label="About {{ author.name }}">
+          <img
+            class="rounded-circle border"
+            src="{{ profile_image | relative_url }}"
+            alt="{{ author.name }}"
+            width="112"
+            height="112"
+            loading="lazy"
+            style="object-fit: cover;"
+          >
+        </a>
+      {%- endif -%}
+
+      <div class="flex-grow-1">
+        <p class="text-body-secondary small text-uppercase fw-semibold mb-1">About the author</p>
+        <h2 class="h4 mb-1">{{ author.name }}</h2>
+        {%- if author.role and author.role != "" -%}
+          <p class="fw-semibold mb-2">{{ author.role }}</p>
+        {%- endif -%}
+        {%- if author.bio and author.bio != "" -%}
+          <p class="mb-3">{{ author.bio }}</p>
+        {%- endif -%}
+
+        {%- if author.focus and variant == "about" -%}
+          <ul class="list-unstyled d-flex flex-wrap gap-2 mb-3" aria-label="Engineering focus areas">
+            {%- for item in author.focus -%}
+              <li><span class="badge rounded-pill text-bg-light border">{{ item }}</span></li>
+            {%- endfor -%}
+          </ul>
+        {%- endif -%}
+
+        <div class="d-flex flex-wrap gap-2 align-items-center">
+          {%- unless variant == "about" -%}
+            <a class="btn btn-sm btn-outline-primary" href="{{ '/about/' | relative_url }}">About</a>
+          {%- endunless -%}
+          <a class="btn btn-sm btn-outline-secondary" href="{{ '/projects/' | relative_url }}">Projects</a>
+
+          {%- assign socials = site.data.social | where: "show_in_contact_me", true -%}
+          {%- if socials == empty -%}
+            {%- assign socials = site.data.social | where: "show_in_contact_me", "true" -%}
+          {%- endif -%}
+          {%- for social in socials -%}
+            {%- if social.url and social.url != "" -%}
+              <a
+                class="btn btn-sm btn-link px-1"
+                href="{{ social.url }}"
+                target="_blank"
+                rel="noopener noreferrer me"
+                aria-label="{{ social.name }}"
+                title="{{ social.name }}"
+              ><i class="{{ social.icon }}" aria-hidden="true"></i></a>
+            {%- endif -%}
+          {%- endfor -%}
+        </div>
+      </div>
+    </div>
+  </div>
+</aside>

--- a/_includes/sidebar/aboutme.html
+++ b/_includes/sidebar/aboutme.html
@@ -1,29 +1,32 @@
 <div class="sidebar-module about container">
     <h4>{{ site.data.locales[site.default_locale].Aboutme }}</h4>
-    {%- assign abmPhoto = site.aboutme.photo -%}
-    {%- if abmPhoto.use_github_avatar -%}
-        {%- avatar{{ site.data.social.github.username }}size = 300 -%}
-    {%- elsif abmPhoto.asset_path -%}
+    {%- assign authorPhoto = site.author.image -%}
+    {%- if authorPhoto == nil or authorPhoto == "" -%}
+        {%- assign abmPhoto = site.aboutme.photo -%}
+        {%- if abmPhoto.use_github_avatar -%}
+            {%- avatar{{ site.data.social.github.username }}size = 300 -%}
+        {%- elsif abmPhoto.asset_path -%}
+            {%- assign authorPhoto = abmPhoto.asset_path -%}
+        {%- elsif abmPhoto.hosted_aboutme_photo -%}
+            {%- assign authorPhoto = abmPhoto.hosted_aboutme_photo -%}
+        {%- endif -%}
+    {%- endif -%}
+    {%- if authorPhoto and authorPhoto != "" -%}
         <img
                 title="{{ site.author.name }}"
-                src="{{ abmPhoto.asset_path }}"
-                alt="{{ site.author.name }}"
-        />
-    {%- elsif abmPhoto.hosted_aboutme_photo -%}
-        <img
-                title="{{ site.author.name }}"
-                src="{{ abmPhoto.hosted_aboutme_photo }}"
+                src="{{ authorPhoto }}"
                 alt="{{ site.author.name }}"
         />
     {%- endif -%}
     <br>
-    <p>{{ site.aboutme.text }}</p>
+    <p>{{ site.author.bio | default: site.aboutme.text }}</p>
+    <p><a href="{{ '/about/' | relative_url }}">More about my work</a></p>
     <br>
 
     {%- if site.show_contact_info == true -%}
 
-    <section id="contact-me">
-        <p>You can contact me via the <a href="/about/#contact-me">Contact Me</a> form or any of the below options:</p>
+    <section id="contact-me-sidebar">
+        <p>You can contact me via the <a href="{{ '/about/#contact-me' | relative_url }}">Contact Me</a> form or any of the options below:</p>
         <div class="row">
             {%- if site.email != empty -%}
                 <div class="col-1 mx-3">
@@ -38,7 +41,7 @@
                     <div class="col-1 mx-3">
                         <a href="{{ social.url }}"
                            target="_blank"
-                           rel="noopener noreferrer"
+                           rel="noopener noreferrer me"
                            title="{{ social.name | capitalize }}: {{ social.username }}"
                         ><i class="{{ social.icon }}" style="font-size: 2rem;"></i>
                         </a>
@@ -46,8 +49,8 @@
                 {%- endfor -%}
             {%- endif -%}
         </div>
-        {%- endif -%}
     </section>
+    {%- endif -%}
 
     <div
             class="fb-like"

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -66,6 +66,9 @@ layout: default
           ></path></svg
         >" -%}
             </article>
+            {%- if site.author and site.author.name -%}
+                {%- include author-card.html variant="post" -%}
+            {%- endif -%}
         </div>
     </div>
 </div>


### PR DESCRIPTION
Implements the reusable theme side of CI-017. Adds a canonical author-card component, renders a compact author authority block beneath posts, modernizes the About include to use structured author data instead of placeholder lorem ipsum, and makes the sidebar prefer the same canonical author bio/image while retaining backwards-compatible fallbacks. Companion JLSunday PR supplies the actual author profile content and temporarily pins this exact theme commit for cross-repo validation.