### PR TITLE
CI-017: fix author Projects links

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -23,7 +23,7 @@
 <section class="about-links my-4" aria-labelledby="about-links-heading">
   <h2 id="about-links-heading">Explore my work</h2>
   <p>
-    <a href="{{ '/projects/' | relative_url }}">Projects and engineering case studies</a>
+    <a href="{{ '/projects' | relative_url }}">Projects and engineering case studies</a>
     ·
     <a href="{{ '/' | relative_url }}">Latest writing</a>
   </p>

--- a/_includes/author-card.html
+++ b/_includes/author-card.html
@@ -46,7 +46,7 @@
           {%- unless variant == "about" -%}
             <a class="btn btn-sm btn-outline-primary" href="{{ '/about/' | relative_url }}">About</a>
           {%- endunless -%}
-          <a class="btn btn-sm btn-outline-secondary" href="{{ '/projects/' | relative_url }}">Projects</a>
+          <a class="btn btn-sm btn-outline-secondary" href="{{ '/projects' | relative_url }}">Projects</a>
 
           {%- assign socials = site.data.social | where: "show_in_contact_me", true -%}
           {%- if socials == empty -%}


### PR DESCRIPTION
Fixes the reusable author/About presentation to use JLSunday's canonical `/projects` permalink instead of `/projects/`, which GitHub Pages serves differently from the local Jekyll server. Companion JLSunday changes add generated-site regression coverage for the Projects CTA and author-card social links.