### PR TITLE
CI-017: refine author card layout

### DIFF
--- a/_includes/author-card.html
+++ b/_includes/author-card.html
@@ -13,7 +13,7 @@
       {%- if profile_image and profile_image != "" -%}
         <a href="{{ '/about/' | relative_url }}" class="flex-shrink-0 align-self-start" aria-label="About {{ author.name }}">
           <img
-            class="rounded-circle border"
+            class="author-card-profile-image rounded-circle border"
             src="{{ profile_image | relative_url }}"
             alt="{{ author.name }}"
             width="128"
@@ -26,7 +26,7 @@
 
       <div class="flex-grow-1">
         {%- unless variant == "about" -%}
-          <p class="text-body-secondary small text-uppercase fw-semibold mb-2">About the author</p>
+          <p class="author-card-eyebrow text-body-secondary small text-uppercase fw-semibold mb-2">About the author</p>
         {%- endunless -%}
 
         <div class="mb-3">
@@ -63,7 +63,7 @@
         {%- assign socials = site.data.social | where: "show_in_contact_me", "true" -%}
       {%- endif -%}
       {%- if socials and socials != empty -%}
-        <nav class="d-flex flex-wrap gap-1 align-items-center" aria-label="Author profiles">
+        <nav class="author-card-socials d-flex flex-wrap gap-1 align-items-center" aria-label="Author profiles">
           {%- for social in socials -%}
             {%- if social.url and social.url != "" -%}
               <a

--- a/_includes/author-card.html
+++ b/_includes/author-card.html
@@ -7,17 +7,17 @@
   {%- endif -%}
 {%- endif -%}
 
-<aside class="author-card card my-4 mx-auto" aria-label="About the author" style="max-width: 880px;">
-  <div class="card-body p-4 p-lg-5">
-    <div class="d-flex flex-column flex-md-row gap-4 align-items-md-start">
+<aside class="author-card card my-4 mx-auto" aria-label="About the author" style="max-width: 820px;">
+  <div class="card-body p-4">
+    <div class="d-flex flex-column flex-sm-row gap-3 align-items-sm-start">
       {%- if profile_image and profile_image != "" -%}
         <a href="{{ '/about/' | relative_url }}" class="flex-shrink-0 align-self-start" aria-label="About {{ author.name }}">
           <img
             class="author-card-profile-image rounded-circle border"
             src="{{ profile_image | relative_url }}"
             alt="{{ author.name }}"
-            width="128"
-            height="128"
+            width="112"
+            height="112"
             loading="lazy"
             style="object-fit: cover;"
           >
@@ -25,12 +25,10 @@
       {%- endif -%}
 
       <div class="flex-grow-1">
-        {%- unless variant == "about" -%}
-          <p class="author-card-eyebrow text-body-secondary small text-uppercase fw-semibold mb-2">About the author</p>
-        {%- endunless -%}
+        <p class="author-card-eyebrow text-body-secondary small text-uppercase fw-semibold mb-1">About the author</p>
 
-        <div class="mb-3">
-          <h2 class="h3 mb-1">{{ author.name }}</h2>
+        <div class="mb-2">
+          <h2 class="h4 mb-1">{{ author.name }}</h2>
           {%- if author.role and author.role != "" -%}
             <p class="text-body-secondary fw-semibold mb-0">{{ author.role }}</p>
           {%- endif -%}
@@ -43,27 +41,25 @@
         {%- if author.focus and variant == "about" -%}
           <ul class="list-unstyled d-flex flex-wrap gap-2 mb-0" aria-label="Engineering focus areas">
             {%- for item in author.focus -%}
-              <li><span class="badge rounded-pill border bg-body-tertiary text-body-secondary fw-normal px-3 py-2">{{ item }}</span></li>
+              <li><span class="badge rounded-pill border bg-body-tertiary text-body-secondary fw-normal px-2 py-1">{{ item }}</span></li>
             {%- endfor -%}
           </ul>
         {%- endif -%}
       </div>
     </div>
 
-    <div class="author-card-actions border-top mt-4 pt-3 d-flex flex-column flex-sm-row gap-3 justify-content-between align-items-sm-center">
-      <div class="d-flex flex-wrap gap-2">
-        {%- unless variant == "about" -%}
-          <a class="btn btn-sm btn-outline-primary" href="{{ '/about/' | relative_url }}">About</a>
-        {%- endunless -%}
-        <a class="btn btn-sm btn-outline-secondary" href="{{ '/projects' | relative_url }}">Projects</a>
-      </div>
+    <div class="author-card-actions border-top mt-3 pt-3 d-flex flex-wrap gap-2 align-items-center">
+      {%- unless variant == "about" -%}
+        <a class="btn btn-sm btn-outline-primary" href="{{ '/about/' | relative_url }}">About</a>
+      {%- endunless -%}
+      <a class="btn btn-sm btn-outline-secondary" href="{{ '/projects' | relative_url }}">Projects</a>
 
       {%- assign socials = site.data.social | where: "show_in_contact_me", true -%}
       {%- if socials == empty -%}
         {%- assign socials = site.data.social | where: "show_in_contact_me", "true" -%}
       {%- endif -%}
       {%- if socials and socials != empty -%}
-        <nav class="author-card-socials d-flex flex-wrap gap-1 align-items-center" aria-label="Author profiles">
+        <nav class="author-card-socials d-flex flex-wrap gap-1 align-items-center ms-sm-1" aria-label="Author profiles">
           {%- for social in socials -%}
             {%- if social.url and social.url != "" -%}
               <a

--- a/_includes/author-card.html
+++ b/_includes/author-card.html
@@ -9,44 +9,77 @@
 
 <aside class="author-card card my-4 mx-auto" aria-label="About the author" style="max-width: 820px;">
   <div class="card-body p-4">
-    <div class="d-flex flex-column flex-sm-row gap-3 align-items-sm-start">
-      {%- if profile_image and profile_image != "" -%}
-        <a href="{{ '/about/' | relative_url }}" class="flex-shrink-0 align-self-start" aria-label="About {{ author.name }}">
-          <img
-            class="author-card-profile-image rounded-circle border"
-            src="{{ profile_image | relative_url }}"
-            alt="{{ author.name }}"
-            width="112"
-            height="112"
-            loading="lazy"
-            style="object-fit: cover;"
-          >
-        </a>
-      {%- endif -%}
+    {%- if variant == "about" -%}
+      <div class="d-flex flex-column flex-md-row-reverse gap-4 align-items-start">
+        {%- if profile_image and profile_image != "" -%}
+          <a href="{{ '/about/' | relative_url }}" class="flex-shrink-0 align-self-end align-self-md-start" aria-label="About {{ author.name }}">
+            <img
+              class="author-card-profile-image author-card-profile-image-about rounded-3 border"
+              src="{{ profile_image | relative_url }}"
+              alt="{{ author.name }}"
+              width="144"
+              height="144"
+              loading="lazy"
+              style="object-fit: cover;"
+            >
+          </a>
+        {%- endif -%}
 
-      <div class="flex-grow-1">
-        <p class="author-card-eyebrow text-body-secondary small text-uppercase fw-semibold mb-1">About the author</p>
+        <div class="flex-grow-1">
+          <p class="author-card-eyebrow text-body-secondary small text-uppercase fw-semibold mb-1">About the author</p>
 
-        <div class="mb-2">
-          <h2 class="h4 mb-1">{{ author.name }}</h2>
-          {%- if author.role and author.role != "" -%}
-            <p class="text-body-secondary fw-semibold mb-0">{{ author.role }}</p>
+          <div class="mb-2">
+            <h2 class="h4 mb-1">{{ author.name }}</h2>
+            {%- if author.role and author.role != "" -%}
+              <p class="text-body-secondary fw-semibold mb-0">{{ author.role }}</p>
+            {%- endif -%}
+          </div>
+
+          {%- if author.bio and author.bio != "" -%}
+            <p class="mb-3">{{ author.bio }}</p>
+          {%- endif -%}
+
+          {%- if author.focus -%}
+            <ul class="list-unstyled d-flex flex-wrap gap-2 mb-0" aria-label="Engineering focus areas">
+              {%- for item in author.focus -%}
+                <li><span class="badge rounded-pill border bg-body-tertiary text-body-secondary fw-normal px-2 py-1">{{ item }}</span></li>
+              {%- endfor -%}
+            </ul>
           {%- endif -%}
         </div>
-
-        {%- if author.bio and author.bio != "" -%}
-          <p class="mb-3">{{ author.bio }}</p>
-        {%- endif -%}
-
-        {%- if author.focus and variant == "about" -%}
-          <ul class="list-unstyled d-flex flex-wrap gap-2 mb-0" aria-label="Engineering focus areas">
-            {%- for item in author.focus -%}
-              <li><span class="badge rounded-pill border bg-body-tertiary text-body-secondary fw-normal px-2 py-1">{{ item }}</span></li>
-            {%- endfor -%}
-          </ul>
-        {%- endif -%}
       </div>
-    </div>
+    {%- else -%}
+      <div class="d-flex flex-column flex-sm-row gap-3 align-items-sm-start">
+        {%- if profile_image and profile_image != "" -%}
+          <a href="{{ '/about/' | relative_url }}" class="flex-shrink-0 align-self-start" aria-label="About {{ author.name }}">
+            <img
+              class="author-card-profile-image author-card-profile-image-post rounded-circle border"
+              src="{{ profile_image | relative_url }}"
+              alt="{{ author.name }}"
+              width="112"
+              height="112"
+              loading="lazy"
+              style="object-fit: cover;"
+            >
+          </a>
+        {%- endif -%}
+
+        <div class="flex-grow-1">
+          <p class="author-card-eyebrow text-body-secondary small text-uppercase fw-semibold mb-1">About the author</p>
+
+          <div class="mb-2">
+            <h2 class="h4 mb-1">{{ author.name }}</h2>
+            {%- if author.role and author.role != "" -%}
+              <p class="text-body-secondary fw-semibold mb-0">{{ author.role }}</p>
+            {%- endif -%}
+          </div>
+
+          {%- if author.bio and author.bio != "" -%}
+            <p class="mb-3">{{ author.bio }}</p>
+          {%- endif -%}
+        </div>
+      </div>
+    {%- endif -%}
 
     <div class="author-card-actions border-top mt-3 pt-3 d-flex flex-wrap gap-2 align-items-center">
       {%- unless variant == "about" -%}

--- a/_includes/author-card.html
+++ b/_includes/author-card.html
@@ -7,17 +7,17 @@
   {%- endif -%}
 {%- endif -%}
 
-<aside class="author-card card my-4" aria-label="About the author">
-  <div class="card-body">
-    <div class="d-flex flex-column flex-sm-row gap-3 align-items-sm-center">
+<aside class="author-card card my-4 mx-auto" aria-label="About the author" style="max-width: 880px;">
+  <div class="card-body p-4 p-lg-5">
+    <div class="d-flex flex-column flex-md-row gap-4 align-items-md-start">
       {%- if profile_image and profile_image != "" -%}
-        <a href="{{ '/about/' | relative_url }}" class="flex-shrink-0" aria-label="About {{ author.name }}">
+        <a href="{{ '/about/' | relative_url }}" class="flex-shrink-0 align-self-start" aria-label="About {{ author.name }}">
           <img
             class="rounded-circle border"
             src="{{ profile_image | relative_url }}"
             alt="{{ author.name }}"
-            width="112"
-            height="112"
+            width="128"
+            height="128"
             loading="lazy"
             style="object-fit: cover;"
           >
@@ -25,37 +25,49 @@
       {%- endif -%}
 
       <div class="flex-grow-1">
-        <p class="text-body-secondary small text-uppercase fw-semibold mb-1">About the author</p>
-        <h2 class="h4 mb-1">{{ author.name }}</h2>
-        {%- if author.role and author.role != "" -%}
-          <p class="fw-semibold mb-2">{{ author.role }}</p>
-        {%- endif -%}
+        {%- unless variant == "about" -%}
+          <p class="text-body-secondary small text-uppercase fw-semibold mb-2">About the author</p>
+        {%- endunless -%}
+
+        <div class="mb-3">
+          <h2 class="h3 mb-1">{{ author.name }}</h2>
+          {%- if author.role and author.role != "" -%}
+            <p class="text-body-secondary fw-semibold mb-0">{{ author.role }}</p>
+          {%- endif -%}
+        </div>
+
         {%- if author.bio and author.bio != "" -%}
           <p class="mb-3">{{ author.bio }}</p>
         {%- endif -%}
 
         {%- if author.focus and variant == "about" -%}
-          <ul class="list-unstyled d-flex flex-wrap gap-2 mb-3" aria-label="Engineering focus areas">
+          <ul class="list-unstyled d-flex flex-wrap gap-2 mb-0" aria-label="Engineering focus areas">
             {%- for item in author.focus -%}
-              <li><span class="badge rounded-pill text-bg-light border">{{ item }}</span></li>
+              <li><span class="badge rounded-pill border bg-body-tertiary text-body-secondary fw-normal px-3 py-2">{{ item }}</span></li>
             {%- endfor -%}
           </ul>
         {%- endif -%}
+      </div>
+    </div>
 
-        <div class="d-flex flex-wrap gap-2 align-items-center">
-          {%- unless variant == "about" -%}
-            <a class="btn btn-sm btn-outline-primary" href="{{ '/about/' | relative_url }}">About</a>
-          {%- endunless -%}
-          <a class="btn btn-sm btn-outline-secondary" href="{{ '/projects' | relative_url }}">Projects</a>
+    <div class="author-card-actions border-top mt-4 pt-3 d-flex flex-column flex-sm-row gap-3 justify-content-between align-items-sm-center">
+      <div class="d-flex flex-wrap gap-2">
+        {%- unless variant == "about" -%}
+          <a class="btn btn-sm btn-outline-primary" href="{{ '/about/' | relative_url }}">About</a>
+        {%- endunless -%}
+        <a class="btn btn-sm btn-outline-secondary" href="{{ '/projects' | relative_url }}">Projects</a>
+      </div>
 
-          {%- assign socials = site.data.social | where: "show_in_contact_me", true -%}
-          {%- if socials == empty -%}
-            {%- assign socials = site.data.social | where: "show_in_contact_me", "true" -%}
-          {%- endif -%}
+      {%- assign socials = site.data.social | where: "show_in_contact_me", true -%}
+      {%- if socials == empty -%}
+        {%- assign socials = site.data.social | where: "show_in_contact_me", "true" -%}
+      {%- endif -%}
+      {%- if socials and socials != empty -%}
+        <nav class="d-flex flex-wrap gap-1 align-items-center" aria-label="Author profiles">
           {%- for social in socials -%}
             {%- if social.url and social.url != "" -%}
               <a
-                class="btn btn-sm btn-link px-1"
+                class="btn btn-sm btn-link text-body-secondary px-2"
                 href="{{ social.url }}"
                 target="_blank"
                 rel="noopener noreferrer me"
@@ -64,8 +76,8 @@
               ><i class="{{ social.icon }}" aria-hidden="true"></i></a>
             {%- endif -%}
           {%- endfor -%}
-        </div>
-      </div>
+        </nav>
+      {%- endif -%}
     </div>
   </div>
 </aside>


### PR DESCRIPTION
Refines the reusable author/profile card into a more deliberate professional profile layout. The portrait is enlarged to 128px and top-aligned; name/role hierarchy is stronger; the About-page variant drops the redundant “About the author” eyebrow; expertise pills are more subdued; and Projects/social links move into a separated action footer with an accessible Author profiles nav. Responsive behavior stacks naturally on small screens. This builds on the already-merged Projects-link fix and JLSunday generated-link regression coverage.