### PR TITLE
Add long-form article reading aids

### DIFF
--- a/_sass/_long-form.scss
+++ b/_sass/_long-form.scss
@@ -1,0 +1,81 @@
+.post .post-content {
+  .article-deck {
+    margin-top: -.65rem;
+    margin-bottom: 1.5rem;
+    color: var(--bs-secondary-color);
+    font-size: 1rem;
+    line-height: 1.55;
+  }
+
+  .article-tldr {
+    margin: 1.75rem 0 2rem;
+    padding: 1.1rem 1.25rem;
+    border: 1px solid var(--bs-border-color);
+    border-left: .3rem solid $brand-dark-color;
+    border-radius: $border-radius;
+    background: var(--bs-tertiary-bg);
+
+    .article-tldr-title {
+      margin: 0;
+      font-size: 1.2rem;
+      font-weight: 700;
+      line-height: 1.25;
+    }
+
+    .article-tldr-deck {
+      margin: .15rem 0 .75rem;
+      color: var(--bs-secondary-color);
+      font-size: .95rem;
+      font-style: italic;
+    }
+
+    > :last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  .pull-quote {
+    margin: 2.25rem auto;
+    padding: .4rem 0 .4rem 1.25rem;
+    border-left: .35rem solid $brand-dark-color;
+    color: var(--bs-body-color);
+    font-size: clamp(1.25rem, 2.4vw, 1.65rem);
+    font-weight: 600;
+    line-height: 1.4;
+    max-width: 42rem;
+  }
+
+  .article-cta {
+    margin-top: 2.5rem;
+    padding: 1.25rem 1.35rem;
+    border: 1px solid var(--bs-border-color);
+    border-radius: $border-radius;
+    background: var(--bs-tertiary-bg);
+
+    h2,
+    h3 {
+      margin-top: 0;
+    }
+
+    > :last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  @media (max-width: 767.98px) {
+    .article-deck {
+      margin-top: -.45rem;
+      font-size: .95rem;
+    }
+
+    .article-tldr,
+    .article-cta {
+      padding: 1rem;
+    }
+
+    .pull-quote {
+      margin-block: 1.75rem;
+      font-size: 1.2rem;
+    }
+  }
+}

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -115,7 +115,8 @@ $on-laptop:        800px;
         "_syntax-highlighting",
         "_code-blocks",
         "_navigation",
-        "_projects"
+        "_projects",
+        "_long-form"
 ;
 
 @import url('https://fonts.googleapis.com/css?family=Open+Sans');

--- a/docs/long-form-content.md
+++ b/docs/long-form-content.md
@@ -1,0 +1,51 @@
+# Long-form content reading aids
+
+DevSculptor provides optional, content-level presentation helpers for long technical posts. They are intentionally plain HTML classes so posts remain readable if the theme styles are unavailable.
+
+## TLDR block
+
+Use near the beginning of a long article to give scanning readers the core argument.
+
+```html
+<div class="article-tldr">
+  <p class="article-tldr-title">TLDR</p>
+  <p class="article-tldr-deck">The Short Version</p>
+  <p>One concise paragraph that explains the article's main argument.</p>
+</div>
+```
+
+## Section deck
+
+Place immediately beneath a major heading. The heading may be conversational; the deck should state the section's technical purpose in one short sentence.
+
+```html
+<h2>Isn't this just normal software development?</h2>
+<p class="article-deck">Mostly. This section explains the specific decision boundary the workflow formalizes.</p>
+```
+
+Use decks selectively on long-form posts. They should let a reader understand the article's argument by scanning headings and decks without duplicating the first paragraph of every section.
+
+## Pull quote
+
+Use sparingly for conclusions worth remembering. Four to six is usually enough for a long article.
+
+```html
+<blockquote class="pull-quote">
+  A rejected abstraction can be a successful experiment.
+</blockquote>
+```
+
+A pull quote should surface a point already supported by the surrounding article rather than introduce a new claim.
+
+## Call to action
+
+Use at the end when the article has a natural next step such as trying a tool, reviewing a repository, or reporting feedback.
+
+```html
+<div class="article-cta">
+  <h2>Try it on a real decision</h2>
+  <p>Give the reader a specific, low-friction next step.</p>
+</div>
+```
+
+Avoid generic engagement prompts. A useful CTA should follow directly from the substance of the article.


### PR DESCRIPTION
Adds reusable styling primitives for long technical articles:

- `.article-tldr` with title/deck support
- `.article-deck` for one-line explanatory subtitles beneath section headings
- `.pull-quote` for magazine-style highlighted takeaways
- `.article-cta` for end-of-article calls to action

The styles use existing Bootstrap/theme variables so they remain compatible with the theme's current light/dark behavior and degrade to ordinary readable HTML if the styles are unavailable.

This is intended to support the EGCA article currently being drafted in JLSunday, but the primitives are generic enough for future long-form posts.