### PR TITLE
CI-006: use description as canonical post card summary

### DIFF
--- a/_includes/home.html
+++ b/_includes/home.html
@@ -40,12 +40,13 @@
             {% for featured_title in homepage.featured_writing %}
                 {%- assign featured_post = site.posts | where: "title", featured_title | first -%}
                 {% if featured_post %}
+                {%- assign featured_summary = featured_post.description | default: featured_post.summary -%}
                 <div class="col-lg-4 d-flex">
                     <div class="card h-100 w-100">
                         <div class="card-body d-flex flex-column">
                             <p class="small text-body-secondary mb-2">{{ featured_post.date | date: "%b %-d, %Y" }}</p>
                             <h3 class="h4 card-title"><a class="stretched-link post-link" href="{{ featured_post.url | prepend: site.url }}">{{ featured_post.title }}</a></h3>
-                            {% if featured_post.summary %}<p class="card-text text-body-secondary mt-2">{{ featured_post.summary }}</p>{% endif %}
+                            {% if featured_summary %}<p class="card-text text-body-secondary mt-2">{{ featured_summary }}</p>{% endif %}
                         </div>
                     </div>
                 </div>
@@ -106,12 +107,13 @@
         <h2 id="latest-writing-heading" class="mb-4">Latest writing</h2>
         <div class="list-group list-group-flush">
             {% for post in site.posts limit: homepage.latest_count | default: 5 %}
+            {%- assign latest_summary = post.description | default: post.summary -%}
             <a class="list-group-item list-group-item-action px-0 py-3 bg-transparent" href="{{ post.url | prepend: site.url }}">
                 <div class="d-flex flex-column flex-md-row justify-content-between gap-1">
                     <strong>{{ post.title }}</strong>
                     <span class="text-body-secondary small text-nowrap">{{ post.date | date: "%b %-d, %Y" }}</span>
                 </div>
-                {% if post.summary %}<div class="text-body-secondary mt-1">{{ post.summary }}</div>{% endif %}
+                {% if latest_summary %}<div class="text-body-secondary mt-1">{{ latest_summary }}</div>{% endif %}
             </a>
             {% endfor %}
         </div>

--- a/_includes/home/post_card.html
+++ b/_includes/home/post_card.html
@@ -1,4 +1,5 @@
 {%- assign post = include.post -%}
+{%- assign card_summary = post.description | default: post.summary -%}
 <div class="card">
 
     {%- if post.featured -%}
@@ -38,17 +39,17 @@
                 <span class="post-meta"><i class="bi bi-tags" title="{{ locales[site.default_locale].Tags }}"></i></span>
                 {% for tag in post.tags %}
                     <a href="{{ site.baseurl }}/tags/#{{ tag }}"
-                       title="{{ tag }}">{{ tag }}</a>{% unless post.tags.last == tag %}, {% endunless %}
+                       title="{{ tag }}">{{ tag }}</a>{% unless post.tags.last == tag %}, {% endunless -%}
                 {% endfor %}
             {% endif %}
         </p>
         <hr>
         <article itemprop="articleBody">
-            {%- if post.summary -%}
-                <p class="card-text">{{ post.summary }}</p>
+            {%- if card_summary -%}
+                <p class="card-text">{{ card_summary }}</p>
                 <div style="text-align: right"><a href="{{ post.url | prepend: site.url }}">Read more</a></div>
             {%- elsif post.content contains site.excerpt_separator -%}
-                <p class="card-text">{{ post.summary }}</p>
+                <div class="card-text">{{ post.excerpt }}</div>
                 <div style="text-align: right"><a href="{{ post.url | prepend: site.url }}">Read more</a></div>
             {%- else -%}
                 <p class="card-text">{{ post.content }}</p>


### PR DESCRIPTION
Updates reusable post-card/homepage presentation so current-contract posts use `description` as the canonical card summary while preserving `summary` only as a legacy fallback. This is the theme-side prerequisite for JLSunday CI-006 publishing validation, which removes duplicate summary metadata from new posts. JLSunday's integration branch is pinned to the exact commit from this PR for end-to-end Jekyll validation before merge.