### PR TITLE
CI-019: align Twitter description with current post metadata

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,8 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="keywords" content="{{ site.keywords }}">
-<meta name="twitter:description" content="{%- if page.summary -%}{{ page.summary | strip_html | strip_newlines | truncate: 160 }}{%- else -%}{{ site.description }}{%- endif -%}">
+{%- assign social_description = page.description | default: page.summary | default: site.description -%}
+<meta name="twitter:description" content="{{ social_description | strip_html | strip_newlines | truncate: 160 }}">
 
 <link rel="alternate" type="application/atom+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.url }}">
 


### PR DESCRIPTION
Updates DevSculptor's remaining custom social metadata seam for the GitHub Pages `jekyll-seo-tag` 2.8 line: `twitter:description` now prefers `page.description`, falls back to legacy `page.summary`, then site description. OG/Twitter image ownership stays with `jekyll-seo-tag`; no duplicate custom image tags are added. JLSunday's CI-019 branch is pinned to this exact commit and validates fallback/per-post image behavior from generated HTML.