### PR TITLE
Render post hero images near the article top

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -51,6 +51,16 @@ layout: default
             {% include toc.html %}
         {%- endif -%}
         <div class="{% if page.include_TOC %}col-lg-9{% else %}col-lg-9 mx-auto{% endif %}">
+            {%- if page.image -%}
+                <figure class="post-hero">
+                    <img src="{{ page.image | relative_url }}"
+                         alt="{{ page.image_alt | default: page.title | escape }}"
+                         itemprop="image"/>
+                    {%- if page.image_caption -%}
+                        <figcaption>{{ page.image_caption }}</figcaption>
+                    {%- endif -%}
+                </figure>
+            {%- endif -%}
             <article class="post-content" id="article" itemprop="articleBody">
                 {%- include anchor_headings.html html=content anchorBody="<svg
           class='octicon'

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -42,6 +42,26 @@ a {
     margin-top: 1.5rem;
   }
 
+  .post-hero {
+    max-width: 48rem;
+    margin: 0 auto 2rem;
+
+    img {
+      display: block;
+      width: 100%;
+      height: auto;
+      border-radius: $border-radius;
+    }
+
+    figcaption {
+      margin-top: .6rem;
+      color: var(--bs-secondary-color);
+      font-size: $small-font-size;
+      line-height: 1.5;
+      text-align: center;
+    }
+  }
+
   .post-content {
     max-width: 48rem;
     margin-inline: auto;
@@ -233,6 +253,10 @@ a {
   @media (max-width: 767.98px) {
     .post-header {
       text-align: left !important;
+    }
+
+    .post-hero {
+      margin-bottom: 1.5rem;
     }
 
     .post-content {

--- a/docs/post-hero-images.md
+++ b/docs/post-hero-images.md
@@ -1,0 +1,14 @@
+# Post hero images
+
+DevSculptor treats a post's `image` front-matter value as both social metadata and, when present, the visible article hero near the top of the reading column.
+
+## Front matter
+
+```yaml
+image: /assets/images/posts/example.png
+image_alt: "Describe the illustration for readers who cannot see it."
+```
+
+`image_alt` is strongly recommended. When omitted, the post title is used as a fallback alt value. `image_caption` is optional.
+
+The theme renders the hero immediately before the article body, after the post title and metadata. Consumers should not duplicate the same hero image manually inside the Markdown body.


### PR DESCRIPTION
Adds reusable visible hero-image rendering for posts that define `image` front matter. The hero appears immediately before the article body, uses `image_alt` when provided with the post title as fallback, supports optional captions, and is styled responsively in the reading column. This keeps the same image useful for social metadata and visible article presentation without duplicating Markdown image markup.