### PR TITLE
Avoid rendering default social image as post hero

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -51,7 +51,7 @@ layout: default
             {% include toc.html %}
         {%- endif -%}
         <div class="{% if page.include_TOC %}col-lg-9{% else %}col-lg-9 mx-auto{% endif %}">
-            {%- if page.image -%}
+            {%- if page.image and page.image.path == nil -%}
                 <figure class="post-hero">
                     <img src="{{ page.image | relative_url }}"
                          alt="{{ page.image_alt | default: page.title | escape }}"


### PR DESCRIPTION
The new visible post-hero behavior treated any `page.image` value as a hero. JLSunday supplies its site-wide social fallback as an image object through defaults, which caused legacy posts without explicit hero images to render the serialized object as an image URL. This change renders a visible hero only when `page.image` is the explicit string form used by article front matter. JLSunday's site-wide generated link/image integrity check exposed the issue.